### PR TITLE
Consider only horizontal accuracy

### DIFF
--- a/src/interfaces/nmea_gps_interface.cpp
+++ b/src/interfaces/nmea_gps_interface.cpp
@@ -77,8 +77,7 @@ xbot::driver::gps::NmeaGpsInterface::NmeaGpsInterface() : GpsInterface(), gps(pa
         gps_state_.pos_n = n - datum_n_;
         gps_state_.pos_u = fix.altitude - datum_u_;
 
-        gps_state_.position_accuracy = (double) sqrt(
-                pow(fix.horizontalAccuracy(), 2) + pow(fix.verticalAccuracy(), 2));
+        gps_state_.position_accuracy = fix.horizontalAccuracy();
 
         // speed in m/s
         double speed = fix.speed / 3.6;

--- a/src/interfaces/ublox_gps_interface.cpp
+++ b/src/interfaces/ublox_gps_interface.cpp
@@ -211,8 +211,7 @@ namespace xbot {
                 gps_state_.pos_e = e - datum_e_;
                 gps_state_.pos_n = n - datum_n_;
                 gps_state_.pos_u = u - datum_u_;
-                gps_state_.position_accuracy = (double) sqrt(
-                        pow((double) msg->hAcc / 1000.0, 2) + pow((double) msg->vAcc / 1000.0, 2));
+                gps_state_.position_accuracy = (double) msg->hAcc / 1000.0;
 
                 gps_state_.vel_e = msg->velE / 1000.0;
                 gps_state_.vel_n = msg->velN / 1000.0;
@@ -427,4 +426,3 @@ namespace xbot {
         }
     }
 }
-


### PR DESCRIPTION
Since the mower doesn't fly, we don't need to care about vertical accuracy, therefore this change makes the reported accuracy track better what we're really concerned about.