### PR TITLE
Say we have 8 satellites instead of 0 in message sent to NTRIP server

### DIFF
--- a/src/driver_gps_node.cpp
+++ b/src/driver_gps_node.cpp
@@ -76,7 +76,7 @@ void generate_nmea(double lat_in, double lon_in) {
                lat.substr(0, lat.length() - 1) << "," <<
                lat_hemisphere << "," <<
                lon.substr(0, lon.length() - 1) << "," <<
-               lon_hemisphere << ",1,0,0,0,M,0,M,0000,";
+               lon_hemisphere << ",1,8,0,0,M,0,M,0000,";
 
     //build message
     cmd1.name = "GPGGA";


### PR DESCRIPTION
Some VRS stations will ignore messages with too few satellites listed.  Since we are just synthesizing this message, we can just say the number of satellites is "8" and it will work with more NTRIP servers.